### PR TITLE
Fix program exit typo

### DIFF
--- a/UserManagement/User.java
+++ b/UserManagement/User.java
@@ -142,8 +142,8 @@ public class User {
     }
 
     // Gut: Exit-Logik beendet das Programm klar
-    public User ExitProgramm() {
-        System.out.println("\nProgramm has been closed");
+    public User ExitProgram() {
+        System.out.println("\nProgram has been closed");
         System.out.println("Good bye!");
         System.exit(0); // Verbesserung: Programm könnte Ressourcen vor dem Exit freigeben
         return null;

--- a/UserManagement/UserManager.java
+++ b/UserManagement/UserManager.java
@@ -61,7 +61,7 @@ public class UserManager {
                         case 5:
                             return admin.ChangePassword(curUser, sc);
                         case 6:
-                            return admin.ExitProgramm();
+                            return admin.ExitProgram();
                         default:
                             System.out.println("\nInvalid option"); // Gut: Rückmeldung für ungültige Eingabe
                             break;
@@ -98,7 +98,7 @@ public class UserManager {
                     case 4:
                         return curUser.ChangePassword(curUser, sc);
                     case 5:
-                        return curUser.ExitProgramm();
+                        return curUser.ExitProgram();
                     default:
                         System.out.println("\nInvalid option"); // Gut: Rückmeldung für ungültige Auswahl
                         break;


### PR DESCRIPTION
## Summary
- fix method name typo ExitProgram
- update switch cases to use the new method name
- correct console message when closing the program

## Testing
- `javac UserManagement/*.java`

------
https://chatgpt.com/codex/tasks/task_e_68401838f62c832db1e7108016f4008f